### PR TITLE
feat: lint theme reusable action

### DIFF
--- a/.github/workflows/lint-theme.yml
+++ b/.github/workflows/lint-theme.yml
@@ -1,0 +1,19 @@
+name: Lint Theme Styles
+on:
+  workflow_call:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '18' ]
+    name: Node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm run install-build-tools
+      - run: npm test

--- a/dist/index.js
+++ b/dist/index.js
@@ -11032,7 +11032,6 @@ const core = __nccwpck_require__(8890);
 const { Octokit } = __nccwpck_require__(8790);
 
 const reposToDispatchComposerUpdate = [
-    'uses-updater',
     'pressbooksedu-golden-bedrock',
     'client-bedrock',
     'pressbookspublic-bedrock',

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const core = require('@actions/core');
 const { Octokit } = require("@octokit/action");
 
 const reposToDispatchComposerUpdate = [
-    'uses-updater',
     'pressbooksedu-golden-bedrock',
     'client-bedrock',
     'pressbookspublic-bedrock',


### PR DESCRIPTION
This PR centralice the Theme linting in all Pressbooks Themes, this also remove bedrock testing repository this will help us to cut a new release and take advantage of a PR opened in a lot of repos