### PR TITLE
chore: update branch ref to use dev instead of development

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ try {
             owner: 'pressbooks',
             repo: repo,
             workflow_id: 'autoupdate.yml',
-            ref: 'development',
+            ref: 'dev',
         }).then((response) => {
             console.log(`Github API response: ${response}`);
         });


### PR DESCRIPTION
issue: #pressbooks/private/issues/972

Update auto composer update on bedrocks to use dev instead of development
