### PR TITLE
fix: append flag to not open tons of pull requests

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -28,4 +28,5 @@ jobs:
           GITHUB_TOKEN: ${{secrets.PAT_FOR_GITHUB_ACTIONS}}
           GIT_NAME: Pressbooks 🤖
           GIT_EMAIL: ops@pressbooks.com
+          APP_SINGLE_BRANCH: true
           COMPOSER_PACKAGES: 'pressbooks/*'


### PR DESCRIPTION
This flag hopefully will address the race conditions when merging a lot of Pull requests

```
You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.
```
