### PR TITLE
fix: bump github actions scripts

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,18 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge composer update PRs
-        uses: actions/github-script@0.2.0
+        uses: actions/github-script@v6
         env:
           GITHUB_TOKEN: ${{secrets.PAT_FOR_GITHUB_ACTIONS}}
         with:
+          result-encoding: string
           script: |
-            github.pullRequests.createReview({
+            github.rest.pulls.createReview({
               owner: context.payload.repository.owner.login,
               repo: context.payload.repository.name,
               pull_number: context.payload.pull_request.number,
               event: 'APPROVE'
             })
-            github.pullRequests.merge({
+            github.rest.pulls.merge({
               owner: context.payload.repository.owner.login,
               repo: context.payload.repository.name,
               pull_number: context.payload.pull_request.number


### PR DESCRIPTION
This will address 

```
--
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/github-script@0.2.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.Show more
```