### PR TITLE
chore: remove retired bedrocks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11033,10 +11033,8 @@ const {Octokit} = __nccwpck_require__(4428);
 
 const reposToDispatchComposerUpdate = [
     'pressbooksedu-golden-bedrock',
-    'client-bedrock',
     'pressbookspublic-bedrock',
-    'pressbookspub-bedrock',
-    'wisc-bedrock'
+    'pressbookspub-bedrock'
 ];
 
 try {

--- a/index.js
+++ b/index.js
@@ -3,10 +3,8 @@ const {Octokit} = require("@octokit/action");
 
 const reposToDispatchComposerUpdate = [
     'pressbooksedu-golden-bedrock',
-    'client-bedrock',
     'pressbookspublic-bedrock',
-    'pressbookspub-bedrock',
-    'wisc-bedrock'
+    'pressbookspub-bedrock'
 ];
 
 try {


### PR DESCRIPTION
We've retired two bedrocks, so we can remove them from the autoupdater.