### PR TITLE
fix: bump update action

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Add HTTP basic auth credentials
         run: echo '${{ secrets.COMPOSER_AUTH_JSON }}' > $GITHUB_WORKSPACE/auth.json
       - name: composer update action
-        uses: kawax/composer-update-action@v3
+        uses: kawax/composer-update-action@master
         env:
           GITHUB_TOKEN: ${{secrets.PAT_FOR_GITHUB_ACTIONS}}
           GIT_NAME: Pressbooks 🤖


### PR DESCRIPTION
This would update https://github.com/kawax/composer-update-action to use the master branch that contains the latest goodies and it will add the composer update dump into the commit message